### PR TITLE
Set TCP_NODELAY on the RethinkDB connection to avoid Nagle's algorithm delay

### DIFF
--- a/src/main/java/com/rethinkdb/SocketChannelFacade.java
+++ b/src/main/java/com/rethinkdb/SocketChannelFacade.java
@@ -6,6 +6,7 @@ import com.rethinkdb.util.ThreadUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.SocketChannel;
@@ -17,6 +18,7 @@ public class SocketChannelFacade {
         try {
             socketChannel = SocketChannel.open();
             socketChannel.configureBlocking(true);
+            socketChannel.setOption(StandardSocketOptions.TCP_NODELAY, true);
             socketChannel.connect(new InetSocketAddress(hostname, port));
         } catch (IOException e) {
             throw new RethinkDBException(e);


### PR DESCRIPTION
We were seeing simple local gets (which should have taken ~1ms according to the query profiler) take ~40ms with this driver. @danielmewes suggested setting TCP_NODELAY on the SocketChannel to avoid delays caused by [Nagle's algorithm](http://en.wikipedia.org/wiki/Nagle%27s_algorithm).  This fixed our problem.

This fix should be strictly positive for response times.
